### PR TITLE
Disable swipe back gesture

### DIFF
--- a/Source/YPImagePicker.swift
+++ b/Source/YPImagePicker.swift
@@ -61,6 +61,7 @@ public class YPImagePicker: UINavigationController {
         viewControllers = [picker]
         setupLoadingView()
         navigationBar.isTranslucent = false
+        interactivePopGestureRecognizer?.isEnabled = false
 
         picker.didSelectItems = { [weak self] items in
             let showsFilters = YPConfig.showsFilters


### PR DESCRIPTION
We already have a back button, and the swipe back gesture gets in the way when trying to drag the left trim bar. I think we can just disable the swipe back gesture altogether as I don't think there are any screens in our export flow where we actually need this gesture.

Required for resolving issue 168 in related client project.