### PR TITLE
Default initial collection to smart videos

### DIFF
--- a/Source/Pages/Gallery/YPLibraryVC.swift
+++ b/Source/Pages/Gallery/YPLibraryVC.swift
@@ -227,7 +227,16 @@ public class YPLibraryVC: UIViewController, YPPermissionCheckable {
         if let collection = mediaManager.collection {
             mediaManager.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
         } else {
-            mediaManager.fetchResult = PHAsset.fetchAssets(with: options)
+            let albums = YPAlbumsManager().fetchAlbums()
+
+            if let videoAlbum = albums.first(where: { (album) -> Bool in
+                album.collection?.assetCollectionSubtype == .smartAlbumVideos
+            }), let videoCollection = videoAlbum.collection {
+                mediaManager.collection = videoCollection
+                mediaManager.fetchResult = PHAsset.fetchAssets(in: videoCollection, options: options)
+            } else {
+                mediaManager.fetchResult = PHAsset.fetchAssets(with: options)
+            }
         }
                 
         if mediaManager.fetchResult.count > 0 {


### PR DESCRIPTION
There may be a better way, but this approach seems to work too.

This change simply tries to load only the smart video assets at initialization, instead of all assets. As during initialization, there will be no `PHAssetCollection` selected, so it's easy to detect that.

Previously I've tried to programmatically change the album through UI code, but that ended up being messy, unreliable, and a lot of side effects (UI and asset-loading race conditions).